### PR TITLE
feat(dashboard): overview page, auth redirects, split UI components

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Sidebar from "@/components/Sidebar";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 
 export default function DashboardLayout({
   children,
@@ -19,7 +19,9 @@ export default function DashboardLayout({
     const userJson = localStorage.getItem("user");
 
     if (!token) {
-      console.warn("[DashboardLayout] No token detected, redirecting to /login");
+      console.warn(
+        "[DashboardLayout] No token detected, redirecting to /login",
+      );
       router.replace("/login");
       setIsAuthorized(false);
       return;
@@ -30,13 +32,18 @@ export default function DashboardLayout({
       try {
         const user = JSON.parse(userJson);
         if (user.role_id === 1) {
-          console.warn("[DashboardLayout] Regular user detected, redirecting to /unauthorized");
+          console.warn(
+            "[DashboardLayout] Regular user detected, redirecting to /unauthorized",
+          );
           router.replace("/unauthorized");
           setIsAuthorized(false);
           return;
         }
       } catch (e) {
-        console.error("[DashboardLayout] Error parsing user from localStorage:", e);
+        console.error(
+          "[DashboardLayout] Error parsing user from localStorage:",
+          e,
+        );
       }
     }
 
@@ -71,7 +78,11 @@ export default function DashboardLayout({
         onToggle={() => setCollapsed((prev) => !prev)}
       />
       <div
-        style={{ "--sidebar-width": collapsed ? "84px" : "260px" } as React.CSSProperties}
+        style={
+          {
+            "--sidebar-width": collapsed ? "84px" : "260px",
+          } as React.CSSProperties
+        }
         className={`relative isolate flex min-h-screen min-w-0 flex-1 flex-col overflow-hidden bg-linear-to-br from-[#06080f] via-[#0a0b17] to-[#071226] transition-[margin-left] duration-200 ${
           collapsed ? "ml-[84px]" : "ml-[260px]"
         }`}
@@ -82,7 +93,7 @@ export default function DashboardLayout({
           <div className="absolute bottom-[-180px] left-1/3 h-[320px] w-[320px] rounded-full bg-indigo-700/15 blur-3xl" />
         </div>
         <div className="relative z-10 flex min-h-screen min-w-0 flex-1 flex-col">
-        {children}
+          {children}
         </div>
       </div>
     </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,18 +1,91 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { buildDashboardSummaryCards } from "@/components/dashboard/buildSummaryCards";
+import { DashboardCompletionChart } from "@/components/dashboard/DashboardCompletionChart";
+import { DashboardErrorState } from "@/components/dashboard/DashboardErrorState";
+import { DashboardLoadingState } from "@/components/dashboard/DashboardLoadingState";
+import { DashboardRecentActivity } from "@/components/dashboard/DashboardRecentActivity";
+import { DashboardSummaryCards } from "@/components/dashboard/DashboardSummaryCards";
+import { DashboardTopQuestions } from "@/components/dashboard/DashboardTopQuestions";
+import type { DashboardPayload } from "@/components/dashboard/types";
+import Header from "@/components/Header";
+import { Icon } from "@/components/icons/Icon";
+import { api } from "@/lib/api";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 export default function DashboardPage() {
-  const router = useRouter();
+  const [data, setData] = useState<DashboardPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const res = await api.get<DashboardPayload>("/dashboard", {
+      useToken: true,
+    });
+    if (!res.ok || !res.data) {
+      setError(res.error ?? "โหลดข้อมูลไม่สำเร็จ");
+      setData(null);
+      setLoading(false);
+      return;
+    }
+    setData(res.data);
+    setLoading(false);
+  }, []);
 
   useEffect(() => {
-    router.replace("/dashboard/problems");
-  }, [router]);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async dashboard fetch on mount
+    void load();
+  }, [load]);
+
+  const pieRows = useMemo(() => {
+    if (!data?.completion_comparison) return [];
+    const { labels, values } = data.completion_comparison;
+    return labels.map((name, i) => ({
+      name,
+      value: values[i] ?? 0,
+    }));
+  }, [data]);
+
+  const summaryCards = useMemo(
+    () => (data ? buildDashboardSummaryCards(data) : []),
+    [data],
+  );
 
   return (
-    <div className="flex h-full w-full items-center justify-center">
-      <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent"></div>
-    </div>
+    <>
+      <Header
+        title="แดชบอร์ด"
+        icon={<Icon name="stats" className="h-5 w-5" />}
+      />
+      <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 overflow-y-auto px-5 py-8 sm:px-8">
+        {loading ? (
+          <DashboardLoadingState />
+        ) : error ? (
+          <DashboardErrorState
+            message={error}
+            onRetry={() => void load()}
+          />
+        ) : data ? (
+          <>
+            <DashboardSummaryCards cards={summaryCards} />
+            <section className="grid gap-6 lg:grid-cols-2 lg:items-stretch">
+              <DashboardCompletionChart
+                pieRows={pieRows}
+                successfulSubmissions={
+                  data.completion_comparison.successful_submissions
+                }
+                unsuccessfulSubmissions={
+                  data.completion_comparison.unsuccessful_submissions
+                }
+              />
+              <DashboardTopQuestions questions={data.top_questions} />
+            </section>
+            <DashboardRecentActivity rows={data.recent_user_activity} />
+          </>
+        ) : null}
+      </main>
+    </>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -82,7 +82,16 @@ export default function LoginPage() {
 
     setIsLoading(false);
     if (user.role_id === 2) {
-      router.replace("/dashboard/problems");
+      const params = new URLSearchParams(window.location.search);
+      const from = params.get("from");
+      const safeFrom =
+        from &&
+        from.startsWith("/dashboard") &&
+        !from.includes("//") &&
+        !from.includes("\\")
+          ? from
+          : null;
+      router.replace(safeFrom ?? "/dashboard");
     } else {
       router.replace("/");
     }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -12,7 +12,7 @@ export default function NotFoundPage() {
       router.back();
       return;
     }
-    router.replace("/dashboard/problems");
+    router.replace("/dashboard");
   };
 
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -64,7 +64,7 @@ export default function Home() {
               Get Started Now
             </Link>
             <Link
-              href="/dashboard/problems"
+              href="/dashboard"
               className="rounded-full border border-white/20 bg-white/10 px-8 py-3 text-sm font-semibold text-white transition hover:bg-white/20"
             >
               Enter Dashboard

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -73,7 +73,11 @@ export default function RegisterPage() {
       document.cookie = `role_id=${res.data.user.role_id}; path=/; samesite=lax`;
       document.cookie = `display_name=${encodeURIComponent(res.data.user.display_name)}; path=/; samesite=lax`;
       setIsLoading(false);
-      router.replace("/dashboard/problems");
+      if (res.data.user.role_id === 2) {
+        router.replace("/dashboard");
+      } else {
+        router.replace("/");
+      }
       return;
     }
 

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -4,7 +4,6 @@ import { CodeAreaLogo } from "@/components/branding/CodeAreaLogo";
 import { Icon } from "@/components/icons/Icon";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
 
 interface MenuItem {
   label: string;
@@ -13,11 +12,20 @@ interface MenuItem {
 }
 
 interface MenuGroup {
-  title: string;
+  title?: string;
   items: MenuItem[];
 }
 
 const menuGroups: MenuGroup[] = [
+  {
+    items: [
+      {
+        label: "ภาพรวม",
+        href: "/dashboard",
+        iconName: "stats",
+      },
+    ],
+  },
   {
     title: "ทั่วไป",
     items: [
@@ -100,18 +108,21 @@ export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
 
   return (
     <aside
-      className={`fixed bottom-0 left-0 top-0 z-40 flex flex-col overflow-y-auto border-r border-white/10 bg-linear-to-b from-[#05060d]/95 via-[#090b16]/95 to-[#081225]/95 backdrop-blur-md transition-[width] duration-200 ${collapsed ? "w-[84px]" : "w-[260px]"
-        }`}
+      className={`fixed bottom-0 left-0 top-0 z-40 flex flex-col overflow-y-auto border-r border-white/10 bg-linear-to-b from-[#05060d]/95 via-[#090b16]/95 to-[#081225]/95 backdrop-blur-md transition-[width] duration-200 ${
+        collapsed ? "w-[84px]" : "w-[260px]"
+      }`}
     >
       {/* Logo */}
       <div
-        className={`flex h-16 items-center border-b border-white/5 ${collapsed ? "justify-between px-2" : "justify-between px-4"
-          }`}
+        className={`flex h-16 items-center border-b border-white/5 ${
+          collapsed ? "justify-between px-2" : "justify-between px-4"
+        }`}
       >
         <Link
           href="/"
-          className={`flex items-center hover:opacity-90 transition-opacity ${collapsed ? "justify-center pl-1" : "gap-2.5"
-            }`}
+          className={`flex items-center hover:opacity-90 transition-opacity ${
+            collapsed ? "justify-center pl-1" : "gap-2.5"
+          }`}
         >
           <CodeAreaLogo iconClassName="h-8 w-8" />
           {!collapsed ? (
@@ -123,8 +134,9 @@ export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
         <button
           type="button"
           onClick={onToggle}
-          className={`rounded-lg border border-white/10 bg-white/5 text-xs text-white/80 hover:bg-white/10 ${collapsed ? "h-6 w-6" : "h-8 w-8"
-            }`}
+          className={`rounded-lg border border-white/10 bg-white/5 text-xs text-white/80 hover:bg-white/10 ${
+            collapsed ? "h-6 w-6" : "h-8 w-8"
+          }`}
           aria-label={collapsed ? "ขยายเมนู" : "ย่อเมนู"}
         >
           {collapsed ? ">" : "<"}
@@ -135,14 +147,14 @@ export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
       <nav
         className={`flex-1 py-4 ${collapsed ? "px-2 space-y-4" : "px-3 space-y-6"}`}
       >
-        {menuGroups.map((group) => {
+        {menuGroups.map((group, groupIndex) => {
           const visibleItems = group.items;
 
           if (visibleItems.length === 0) return null;
 
           return (
-            <div key={group.title}>
-              {!collapsed ? (
+            <div key={group.title ?? `nav-${groupIndex}`}>
+              {!collapsed && group.title ? (
                 <p className="px-3 mb-2 text-xs font-semibold uppercase tracking-wider text-text-light">
                   {group.title}
                 </p>
@@ -155,13 +167,15 @@ export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
                       <Link
                         title={item.label}
                         href={item.href}
-                        className={`flex items-center rounded-lg text-sm font-medium transition-all duration-150 ${collapsed
-                          ? "justify-center px-2 py-2.5"
-                          : "gap-3 px-3 py-2.5"
-                          } ${isActive
+                        className={`flex items-center rounded-lg text-sm font-medium transition-all duration-150 ${
+                          collapsed
+                            ? "justify-center px-2 py-2.5"
+                            : "gap-3 px-3 py-2.5"
+                        } ${
+                          isActive
                             ? "bg-primary/20 text-primary border border-primary/20"
                             : "text-text-muted hover:bg-white/5 hover:text-foreground"
-                          }`}
+                        }`}
                       >
                         <span
                           className={
@@ -185,10 +199,9 @@ export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
         <button
           type="button"
           onClick={handleLogout}
-          className={`flex w-full items-center rounded-lg text-sm font-medium transition-all duration-150 ${collapsed
-            ? "justify-center px-2 py-2.5"
-            : "gap-3 px-3 py-2.5"
-            } text-red-400/80 hover:bg-red-500/10 hover:text-red-400`}
+          className={`flex w-full items-center rounded-lg text-sm font-medium transition-all duration-150 ${
+            collapsed ? "justify-center px-2 py-2.5" : "gap-3 px-3 py-2.5"
+          } text-red-400/80 hover:bg-red-500/10 hover:text-red-400`}
           title="ออกจากระบบ"
         >
           <span className="text-red-400">

--- a/components/auth/SessionGuard.tsx
+++ b/components/auth/SessionGuard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import Swal from "sweetalert2";
 import { api } from "@/lib/api";
 
@@ -31,6 +31,7 @@ function clearAuthStorage() {
 
 export function SessionGuard() {
   const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     let active = true;
@@ -83,7 +84,10 @@ export function SessionGuard() {
         confirmButtonText: "ตกลง",
       });
 
-      router.replace("/login");
+      const loginHref = pathname.startsWith("/dashboard")
+        ? `/login?from=${encodeURIComponent(pathname)}`
+        : "/login";
+      router.replace(loginHref);
     };
 
     validateSession();
@@ -91,7 +95,7 @@ export function SessionGuard() {
     return () => {
       active = false;
     };
-  }, [router]);
+  }, [router, pathname]);
 
   return null;
 }

--- a/components/dashboard/DashboardCompletionChart.tsx
+++ b/components/dashboard/DashboardCompletionChart.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useId } from "react";
+import {
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+} from "recharts";
+import { DashboardPanelHeader } from "./DashboardPanelHeader";
+import type { PieRow } from "./types";
+import { pieFillForLabel } from "./utils";
+
+type DashboardCompletionChartProps = {
+  pieRows: PieRow[];
+  successfulSubmissions: number;
+  unsuccessfulSubmissions: number;
+};
+
+export function DashboardCompletionChart({
+  pieRows,
+  successfulSubmissions,
+  unsuccessfulSubmissions,
+}: DashboardCompletionChartProps) {
+  const uid = useId().replace(/:/g, "");
+  const successId = `dashPieSuccess-${uid}`;
+  const failId = `dashPieFail-${uid}`;
+
+  return (
+    <div className="flex flex-col rounded-3xl border border-white/[0.08] bg-white/[0.035] p-6 shadow-[0_24px_64px_rgba(0,0,0,0.28)] backdrop-blur-xl">
+      <DashboardPanelHeader
+        className="mb-1"
+        title="เปรียบเทียบความสำเร็จ"
+        subtitle="สัดส่วนการส่งที่สำเร็จและยังไม่สำเร็จ"
+      />
+      <div className="relative mt-2 flex flex-1 flex-col">
+        <div
+          className="pointer-events-none absolute left-1/2 top-1/2 h-[200px] w-[200px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-emerald-500/[0.06] blur-3xl"
+          aria-hidden
+        />
+        <div className="relative h-[300px] w-full min-w-0">
+          <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+            <PieChart>
+              <defs>
+                <linearGradient id={successId} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#5eead4" />
+                  <stop offset="100%" stopColor="#059669" />
+                </linearGradient>
+                <linearGradient id={failId} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#fcd34d" />
+                  <stop offset="100%" stopColor="#ea580c" />
+                </linearGradient>
+              </defs>
+              <Pie
+                data={pieRows}
+                dataKey="value"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                innerRadius="52%"
+                outerRadius="78%"
+                paddingAngle={3}
+                stroke="rgba(255,255,255,0.08)"
+                strokeWidth={2}
+                cornerRadius={4}
+              >
+                {pieRows.map((row) => (
+                  <Cell
+                    key={row.name}
+                    fill={pieFillForLabel(row.name, successId, failId)}
+                  />
+                ))}
+              </Pie>
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "rgba(12,14,24,0.92)",
+                  border: "1px solid rgba(255,255,255,0.1)",
+                  borderRadius: "14px",
+                  fontSize: "12px",
+                  boxShadow: "0 16px 40px rgba(0,0,0,0.45)",
+                }}
+                labelStyle={{ color: "#e2e8f0", marginBottom: 4 }}
+              />
+              <Legend
+                verticalAlign="bottom"
+                wrapperStyle={{
+                  fontSize: "12px",
+                  paddingTop: "12px",
+                }}
+                formatter={(value) => (
+                  <span className="text-white/75">{value}</span>
+                )}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+        <div className="mt-4 flex flex-wrap justify-center gap-3">
+          <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-4 py-1.5 text-xs text-emerald-200/90">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_8px_#34d399]" />
+            สำเร็จ{" "}
+            <strong className="tabular-nums text-emerald-100">
+              {successfulSubmissions.toLocaleString("th-TH")}
+            </strong>
+          </span>
+          <span className="inline-flex items-center gap-2 rounded-full border border-orange-500/20 bg-orange-500/10 px-4 py-1.5 text-xs text-orange-200/90">
+            <span className="h-1.5 w-1.5 rounded-full bg-orange-400 shadow-[0_0_8px_#fb923c]" />
+            ไม่สำเร็จ{" "}
+            <strong className="tabular-nums text-orange-100">
+              {unsuccessfulSubmissions.toLocaleString("th-TH")}
+            </strong>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/DashboardErrorState.tsx
+++ b/components/dashboard/DashboardErrorState.tsx
@@ -1,0 +1,22 @@
+type DashboardErrorStateProps = {
+  message: string;
+  onRetry: () => void;
+};
+
+export function DashboardErrorState({
+  message,
+  onRetry,
+}: DashboardErrorStateProps) {
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-10 text-center shadow-[0_24px_80px_rgba(0,0,0,0.35)] backdrop-blur-xl">
+      <p className="text-sm text-red-300/95">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-5 rounded-2xl bg-primary px-6 py-2.5 text-sm font-semibold text-white shadow-[0_0_28px_rgba(139,92,246,0.35)] transition hover:bg-primary-hover"
+      >
+        ลองอีกครั้ง
+      </button>
+    </div>
+  );
+}

--- a/components/dashboard/DashboardLoadingState.tsx
+++ b/components/dashboard/DashboardLoadingState.tsx
@@ -1,0 +1,8 @@
+export function DashboardLoadingState() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 py-28">
+      <div className="h-11 w-11 animate-spin rounded-full border-2 border-primary/30 border-t-primary" />
+      <p className="text-sm text-white/40">กำลังโหลดภาพรวม…</p>
+    </div>
+  );
+}

--- a/components/dashboard/DashboardPanelHeader.tsx
+++ b/components/dashboard/DashboardPanelHeader.tsx
@@ -1,0 +1,23 @@
+type DashboardPanelHeaderProps = {
+  title: string;
+  subtitle?: string;
+  className?: string;
+};
+
+export function DashboardPanelHeader({
+  title,
+  subtitle,
+  className = "",
+}: DashboardPanelHeaderProps) {
+  return (
+    <div className={`flex items-center gap-3 ${className}`}>
+      <span className="h-6 w-1 rounded-full bg-linear-to-b from-primary to-violet-400 shadow-[0_0_12px_rgba(139,92,246,0.5)]" />
+      <div>
+        <h2 className="text-sm font-bold text-white">{title}</h2>
+        {subtitle ? (
+          <p className="text-xs text-white/40">{subtitle}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/DashboardRecentActivity.tsx
+++ b/components/dashboard/DashboardRecentActivity.tsx
@@ -1,0 +1,87 @@
+import { Icon } from "@/components/icons/Icon";
+import { DashboardPanelHeader } from "./DashboardPanelHeader";
+import type { DashboardPayload } from "./types";
+import { formatThaiDate, initials } from "./utils";
+
+type DashboardRecentActivityProps = {
+  rows: DashboardPayload["recent_user_activity"];
+};
+
+export function DashboardRecentActivity({
+  rows,
+}: DashboardRecentActivityProps) {
+  return (
+    <section className="rounded-3xl border border-white/[0.08] bg-white/[0.035] p-6 pb-2 shadow-[0_24px_64px_rgba(0,0,0,0.28)] backdrop-blur-xl sm:p-7">
+      <div className="mb-5 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <DashboardPanelHeader
+          title="กิจกรรมผู้ใช้งานล่าสุด"
+          subtitle="ผู้ใช้ที่มีการส่งล่าสุดในระบบ"
+        />
+      </div>
+      <div className="-mx-1 overflow-x-auto rounded-2xl border border-white/[0.06] bg-black/20 sm:mx-0">
+        <table className="w-full min-w-[680px] text-left text-sm">
+          <thead>
+            <tr className="border-b border-white/[0.08] bg-white/[0.04] text-[11px] uppercase tracking-[0.12em] text-white/45">
+              <th className="px-5 py-3.5 font-semibold">ชื่อแสดง</th>
+              <th className="px-5 py-3.5 font-semibold">อีเมล</th>
+              <th className="px-5 py-3.5 font-semibold">ส่งล่าสุด</th>
+              <th className="px-5 py-3.5 text-right font-semibold">
+                ความพยายาม
+              </th>
+              <th className="px-5 py-3.5 text-right font-semibold">ผลลัพธ์</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr
+                key={row.user_id}
+                className="border-b border-white/[0.04] transition-colors last:border-0 hover:bg-white/[0.04]"
+              >
+                <td className="px-5 py-3.5">
+                  <div className="flex items-center gap-3">
+                    <span
+                      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-linear-to-br from-white/15 to-white/5 text-xs font-bold text-white/90 ring-1 ring-white/10"
+                      title={row.display_name}
+                    >
+                      {initials(row.display_name)}
+                    </span>
+                    <span className="font-medium text-white/95">
+                      {row.display_name}
+                    </span>
+                  </div>
+                </td>
+                <td className="max-w-[220px] truncate px-5 py-3.5 text-white/55">
+                  {row.email}
+                </td>
+                <td className="whitespace-nowrap px-5 py-3.5 text-white/65">
+                  <span className="inline-flex items-center gap-1.5">
+                    <Icon
+                      name="clock"
+                      className="h-3.5 w-3.5 text-white/30"
+                    />
+                    {formatThaiDate(row.last_submission_at)}
+                  </span>
+                </td>
+                <td className="px-5 py-3.5 text-right">
+                  <span className="tabular-nums text-white/80">
+                    {row.total_attempt.toLocaleString("th-TH")}
+                  </span>
+                </td>
+                <td className="px-5 py-3.5 text-right">
+                  <div className="inline-flex items-center justify-end gap-1.5">
+                    <span className="rounded-md bg-emerald-500/15 px-2 py-0.5 text-xs font-semibold tabular-nums text-emerald-300 ring-1 ring-emerald-400/25">
+                      {row.submissions_passed} ผ่าน
+                    </span>
+                    <span className="rounded-md bg-orange-500/12 px-2 py-0.5 text-xs font-semibold tabular-nums text-orange-300/95 ring-1 ring-orange-400/20">
+                      {row.submissions_not_passed} ไม่ผ่าน
+                    </span>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/components/dashboard/DashboardSummaryCards.tsx
+++ b/components/dashboard/DashboardSummaryCards.tsx
@@ -1,0 +1,38 @@
+import { Icon } from "@/components/icons/Icon";
+import type { DashboardSummaryCard } from "./types";
+
+type DashboardSummaryCardsProps = {
+  cards: DashboardSummaryCard[];
+};
+
+export function DashboardSummaryCards({ cards }: DashboardSummaryCardsProps) {
+  return (
+    <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+      {cards.map((card) => (
+        <div
+          key={card.label}
+          className={`group relative overflow-hidden rounded-3xl border border-white/[0.08] bg-linear-to-br from-white/[0.07] via-white/[0.02] to-transparent p-5 backdrop-blur-md transition duration-300 hover:border-white/[0.12] hover:from-white/[0.09] ${card.glow}`}
+        >
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -right-6 -top-6 h-24 w-24 rounded-full bg-white/[0.04] blur-2xl transition group-hover:bg-white/[0.06]"
+          />
+          <div className="relative flex items-start justify-between gap-3">
+            <div
+              className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-linear-to-br ${card.iconWrap}`}
+            >
+              <Icon name={card.iconName} className="h-5 w-5" />
+            </div>
+          </div>
+          <p className="relative mt-4 text-[11px] font-semibold uppercase tracking-[0.14em] text-white/40">
+            {card.label}
+          </p>
+          <p className="relative mt-1 text-3xl font-bold tabular-nums tracking-tight text-white">
+            {card.value.toLocaleString("th-TH")}
+          </p>
+          <p className="relative mt-2 text-xs text-white/35">{card.hint}</p>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/components/dashboard/DashboardTopQuestions.tsx
+++ b/components/dashboard/DashboardTopQuestions.tsx
@@ -1,0 +1,43 @@
+import { DashboardPanelHeader } from "./DashboardPanelHeader";
+import type { DashboardPayload } from "./types";
+
+type DashboardTopQuestionsProps = {
+  questions: DashboardPayload["top_questions"];
+};
+
+export function DashboardTopQuestions({
+  questions,
+}: DashboardTopQuestionsProps) {
+  return (
+    <div className="flex flex-col rounded-3xl border border-white/[0.08] bg-white/[0.035] p-6 shadow-[0_24px_64px_rgba(0,0,0,0.28)] backdrop-blur-xl">
+      <DashboardPanelHeader
+        className="mb-5"
+        title="โจทย์ยอดนิยม 5 อันดับ"
+        subtitle="เรียงจากจำนวนครั้งที่ถูกส่ง"
+      />
+      <ul className="flex flex-1 flex-col gap-2">
+        {questions.map((q, index) => (
+          <li key={q.question_id}>
+            <div className="group flex items-center gap-3 rounded-2xl border border-transparent bg-white/[0.02] px-3 py-3 transition hover:border-white/[0.08] hover:bg-white/[0.04]">
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-linear-to-br from-primary/30 to-violet-600/10 text-sm font-bold text-violet-200 ring-1 ring-white/10 transition group-hover:from-primary/40 group-hover:ring-primary/25">
+                {index + 1}
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-white/95">
+                  {q.title}
+                </p>
+                <p className="mt-0.5 font-mono text-[11px] text-white/40">
+                  {q.code}
+                </p>
+              </div>
+              <span className="shrink-0 rounded-lg bg-cyan-500/10 px-2.5 py-1 text-xs font-semibold tabular-nums text-cyan-200/95 ring-1 ring-cyan-400/20">
+                {q.submission_count.toLocaleString("th-TH")}{" "}
+                <span className="font-normal text-cyan-200/60">ครั้ง</span>
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/dashboard/buildSummaryCards.ts
+++ b/components/dashboard/buildSummaryCards.ts
@@ -1,0 +1,54 @@
+import type { DashboardPayload, DashboardSummaryCard } from "./types";
+
+export function buildDashboardSummaryCards(
+  data: DashboardPayload,
+): DashboardSummaryCard[] {
+  const done = data.completion_comparison.successful_submissions;
+  return [
+    {
+      label: "จำนวนทดสอบ",
+      hint: "เคสทั้งหมดในระบบ",
+      value: data.test_cases_total,
+      iconName: "cpu",
+      iconWrap:
+        "from-cyan-500/25 to-cyan-600/5 text-cyan-300 shadow-[0_0_24px_rgba(34,211,238,0.12)]",
+      glow: "shadow-[0_0_0_1px_rgba(34,211,238,0.12)]",
+    },
+    {
+      label: "จำนวนคำถาม",
+      hint: "โจทย์ที่เผยแพร่",
+      value: data.questions_total,
+      iconName: "hash",
+      iconWrap:
+        "from-indigo-500/25 to-indigo-600/5 text-indigo-300 shadow-[0_0_24px_rgba(129,140,248,0.12)]",
+      glow: "shadow-[0_0_0_1px_rgba(129,140,248,0.12)]",
+    },
+    {
+      label: "จำนวนแอดมิน",
+      hint: "บัญชีผู้ดูแล",
+      value: data.admins_total,
+      iconName: "shield",
+      iconWrap:
+        "from-violet-500/25 to-violet-600/5 text-violet-300 shadow-[0_0_24px_rgba(167,139,250,0.12)]",
+      glow: "shadow-[0_0_0_1px_rgba(167,139,250,0.12)]",
+    },
+    {
+      label: "จำนวน User",
+      hint: "ผู้ใช้ที่ลงทะเบียน",
+      value: data.users_total,
+      iconName: "users-group",
+      iconWrap:
+        "from-blue-500/25 to-blue-600/5 text-blue-300 shadow-[0_0_24px_rgba(96,165,250,0.12)]",
+      glow: "shadow-[0_0_0_1px_rgba(96,165,250,0.12)]",
+    },
+    {
+      label: "ทำสำเร็จแล้ว",
+      hint: "การส่งที่ผ่านเกณฑ์",
+      value: done,
+      iconName: "check",
+      iconWrap:
+        "from-emerald-500/25 to-emerald-600/5 text-emerald-300 shadow-[0_0_24px_rgba(52,211,153,0.15)]",
+      glow: "shadow-[0_0_0_1px_rgba(52,211,153,0.15)]",
+    },
+  ];
+}

--- a/components/dashboard/types.ts
+++ b/components/dashboard/types.ts
@@ -1,0 +1,39 @@
+export type DashboardPayload = {
+  test_cases_total: number;
+  admins_total: number;
+  questions_total: number;
+  users_total: number;
+  completion_comparison: {
+    labels: string[];
+    successful_submissions: number;
+    unsuccessful_submissions: number;
+    values: number[];
+  };
+  recent_user_activity: Array<{
+    user_id: number;
+    display_name: string;
+    email: string;
+    last_submission_at: string;
+    total_attempt: number;
+    total_finished: number;
+    submissions_passed: number;
+    submissions_not_passed: number;
+  }>;
+  top_questions: Array<{
+    question_id: number;
+    code: string;
+    title: string;
+    submission_count: number;
+  }>;
+};
+
+export type DashboardSummaryCard = {
+  label: string;
+  hint: string;
+  value: number;
+  iconName: string;
+  iconWrap: string;
+  glow: string;
+};
+
+export type PieRow = { name: string; value: number };

--- a/components/dashboard/utils.ts
+++ b/components/dashboard/utils.ts
@@ -1,0 +1,29 @@
+export function pieFillForLabel(
+  name: string,
+  successGradientId: string,
+  failGradientId: string,
+): string {
+  if (name.includes("ไม่")) return `url(#${failGradientId})`;
+  return `url(#${successGradientId})`;
+}
+
+export function formatThaiDate(iso: string) {
+  try {
+    return new Date(iso).toLocaleString("th-TH", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  } catch {
+    return "—";
+  }
+}
+
+export function initials(name: string) {
+  const t = name.trim();
+  if (!t) return "?";
+  const parts = t.split(/\s+/);
+  if (parts.length >= 2) {
+    return (parts[0]!.charAt(0) + parts[1]!.charAt(0)).toUpperCase();
+  }
+  return t.charAt(0).toUpperCase();
+}

--- a/components/navigation/NavigationHeader.tsx
+++ b/components/navigation/NavigationHeader.tsx
@@ -211,11 +211,11 @@ export function NavigationHeader({ links = [] }: NavigationHeaderProps) {
               {isDropdownOpen && (
                 <div className="absolute right-0 mt-2 w-48 bg-[#1a1a2e] border border-white/10 rounded-xl shadow-xl overflow-hidden animate-in fade-in slide-in-from-top-2 duration-200">
                   <Link
-                    href="/dashboard/problems"
+                    href="/dashboard"
                     onClick={() => setIsDropdownOpen(false)}
                     className="w-full text-left px-4 py-3 text-sm text-white/80 hover:bg-white/5 hover:text-blue-400 transition-colors flex items-center gap-2 border-b border-white/5"
                   >
-                    <Icon name="problem" className="w-4 h-4" /> Dashboard
+                    <Icon name="stats" className="w-4 h-4" /> Dashboard
                   </Link>
                   <Link
                     href="/dashboard/settings"


### PR DESCRIPTION
Add admin dashboard at /dashboard backed by the metrics API (summary cards, completion donut, top questions, recent activity).

Default admin entry to /dashboard; sidebar overview link; login supports ?from= for dashboard return paths; SessionGuard preserves path on expiry.

Register sends non-admins home; not-found and marketing dashboard CTA point to /dashboard.

Extract dashboard UI into components/dashboard (types, utils, chart, lists, loading/error).

Sidebar: optional group titles and stable list keys.
Made-with: Cursor