### PR TITLE
hotfix: การแก้ไขระบบ Authentication, หมวดหมู่, และ UI (Auth, Categories & UI Fixes)

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -16,6 +16,7 @@ interface LoginResponse {
     email: string;
     display_name: string;
     role_id: number;
+    avatar_url: string | null;
   };
 }
 
@@ -97,7 +98,7 @@ export default function LoginPage() {
           : null;
       router.replace(safeFrom ?? "/dashboard");
     } else {
-      router.replace("/");
+      router.replace("/profile");
     }
   };
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { Icon } from "@/components/icons/Icon";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -72,10 +72,31 @@ export default function ProfilePage() {
     tags: [] as { name: string; count: number }[],
     solvedQuestions: [] as any[]
   });
-  const [isMounted, setIsMounted] = useState(false);
+  // ใช้ Callback Ref + ResizeObserver ตรวจจับว่า container มีขนาดจริงแล้วจึงแสดง Recharts
+  // Callback ref จะทำงานทันทีที่ DOM element ถูกสร้าง — ไม่ขึ้นกับ isLoading
+  const [chartReady, setChartReady] = useState(false);
+  const roRef = useRef<ResizeObserver | null>(null);
 
-  useEffect(() => {
-    setIsMounted(true);
+  const chartContainerRef = useCallback((node: HTMLDivElement | null) => {
+    // ล้าง observer เก่า
+    if (roRef.current) {
+      roRef.current.disconnect();
+      roRef.current = null;
+    }
+    if (!node) return;
+
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        if (width > 0 && height > 0) {
+          setChartReady(true);
+          ro.disconnect();
+          return;
+        }
+      }
+    });
+    roRef.current = ro;
+    ro.observe(node);
   }, []);
 
   // ฟังก์ชัน fetchData
@@ -326,10 +347,10 @@ export default function ProfilePage() {
                           </button>
                         </div>
 
-                        <div className="flex-1 min-h-[250px] w-full flex items-center justify-center min-w-0 min-h-0">
+                        <div ref={chartContainerRef} className="flex-1 min-h-[250px] w-full flex items-center justify-center">
                           {(chartTab === "category" ? stats.categories : stats.tags).length > 0 ? (
                             <div className="flex-1 flex flex-col w-full h-full">
-                              <div className="relative w-full h-[220px] -ml-2 min-w-0 min-h-0">
+                              <div className="relative w-full h-[220px] -ml-2">
                                 {(() => {
                                   const sourceData = chartTab === "category" ? stats.categories : stats.tags;
                                   const currentData = [...sourceData];
@@ -338,10 +359,10 @@ export default function ProfilePage() {
                                   }
                                   const maxVal = Math.max(...currentData.map(d => d.count), 5);
 
-                                  if (!isMounted) return <div className="w-full h-full bg-white/5 animate-pulse rounded-full" />;
+                                  if (!chartReady) return <div className="w-full h-full bg-white/5 animate-pulse rounded-full" />;
 
                                   return (
-                                    <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} debounce={50}>
+                                    <ResponsiveContainer width="100%" height="100%" debounce={50}>
                                       <RadarChart cx="50%" cy="50%" outerRadius="65%" data={currentData}>
                                         <PolarGrid stroke="rgba(255,255,255,0.1)" />
                                         <PolarAngleAxis dataKey="name" tick={{ fill: 'rgba(255,255,255,0.5)', fontSize: 9, fontWeight: 'bold' }} />

--- a/components/leaderboard/LeaderboardView.tsx
+++ b/components/leaderboard/LeaderboardView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { fetchLeaderboard, type LeaderboardRow } from "@/lib/leaderboardApi";
+import { maskEmail } from "@/lib/utils";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -245,7 +246,7 @@ export default function LeaderboardView() {
                           </td>
                           <td className="px-4 py-3 text-white/45 hidden sm:table-cell">
                             <span className="truncate font-mono text-xs">
-                              {r.email}
+                              {maskEmail(r.email)}
                             </span>
                           </td>
                           <td className="px-4 py-3 text-right font-mono text-violet-200/90">


### PR DESCRIPTION
### การแก้ไข Merge Conflict (Merge Conflict Resolution)
- **LogoutProvider**: ลบโค้ดที่ซ้ำซ้อนจากการ Rebase — มีบล็อก `await performLogout()` และ `router.replace()` หลุดออกมานอก `useCallback` ทำให้เกิด Build Error `"await isn't allowed in non-async function"` ใน [`LogoutProvider.tsx`](frontend/components/auth/LogoutProvider.tsx)
- **NavigationHeader**: ลบการประกาศ `const user = JSON.parse(...)` ที่ซ้ำกัน และกู้คืนการเรียก `setAvatarUrl()` / `setRoleId()` ที่หายไปจากการ Resolve Conflict ใน [`NavigationHeader.tsx`](frontend/components/navigation/NavigationHeader.tsx)

### การแก้ไขหน้าหมวดหมู่โจทย์ (Categories Page Fix)
- **Backend — ลำดับ Route**: ย้าย `/:id` ไปลงทะเบียนหลังเส้นทางเฉพาะ (`/list`, `/search`, `/report`) ใน [`questionCategories.js`](backend/src/routes/questionCategories.js) เพื่อแก้ปัญหาที่ Express จับคู่ `/list` เป็น `id="list"` แล้วตอบ 404
- **Frontend — Anonymous Access**: เปลี่ยน `useToken: true` เป็นการตรวจสอบ Token แบบ Dynamic ใน [`categories/page.tsx`](frontend/app/categories/page.tsx) และ [`categories/[id]/page.tsx`](frontend/app/categories/%5Bid%5D/page.tsx) เพื่อให้ผู้ใช้ที่ยังไม่ล็อกอินสามารถเรียกดูหมวดหมู่ได้

### การแก้ไขรูปโปรไฟล์ใน Navigation (Avatar Fix)
- **Backend — Auth Controller**: เพิ่ม `avatar_url` ในคำสั่ง `select` และ Response ของ Endpoint `login`, `register` และ `me` ใน [`authController.js`](backend/src/controllers/authController.js) เพื่อให้รูปโปรไฟล์ถูกเก็บใน localStorage ตั้งแต่ตอนล็อกอิน
- **Frontend — Login Response Type**: เพิ่ม `avatar_url: string | null` ใน Interface `LoginResponse` ของ [`login/page.tsx`](frontend/app/login/page.tsx)

### การแก้ไขกราฟ Recharts (Chart Dimension Fix)
- **Callback Ref Pattern**: แก้ปัญหา `width(-1) height(-1)` ใน [`profile/page.tsx`](frontend/app/profile/page.tsx) โดยเปลี่ยนจาก `useRef` + `useEffect` เป็น Callback Ref + `ResizeObserver` — ทำให้กราฟแสดงผลหลังจาก container มีขนาดจริงแล้วเท่านั้น ไม่ว่า `isLoading` จะเสร็จเมื่อไหร่

### การปรับปรุง UX หลังล็อกอิน (Post-Login Redirect)
- **ผู้ใช้ทั่วไป**: เปลี่ยน Redirect หลังล็อกอินจาก `/` เป็น `/profile` ใน [`login/page.tsx`](frontend/app/login/page.tsx)
- **แอดมิน**: ยังคง Redirect ไป `/dashboard` ตามเดิม

### ความปลอดภัย — การซ่อนอีเมล (Email Masking)
- **Leaderboard**: ใช้ `maskEmail()` ซ่อนอีเมลถาวรใน [`LeaderboardView.tsx`](frontend/components/leaderboard/LeaderboardView.tsx) โดยไม่มีปุ่มเปิดเผย — ป้องกันข้อมูลส่วนตัวของผู้ใช้จากหน้าสาธารณะ (ต่างจากหน้า Admin ที่สามารถ Toggle ได้)

### การบังคับสิทธิ์ก่อนรันและส่งโค้ด (Authentication Enforcement)
- **Guard ก่อนรันทดสอบ**: เพิ่มฟังก์ชัน `isLoggedIn()` ใน [`ProblemCodeExecutor.tsx`](frontend/components/editor/ProblemCodeExecutor.tsx) เพื่อตรวจสอบ Token ก่อนเรียก API รันโค้ด
- **Guard ก่อนส่งโค้ด (Submit)**: เพิ่มการตรวจสอบสิทธิ์ก่อนส่งโค้ดเพื่อป้องกันข้อผิดพลาด 401

### การปรับปรุง UI แสดงข้อผิดพลาด (Error UI Improvements)
- **เปลี่ยนสีข้อผิดพลาดจากแดงเป็นอำพัน**: ปรับ Error Banner ใน [`SampleRunResultView.tsx`](frontend/components/editor/SampleRunResultView.tsx) จาก `red-400` เป็น `amber-500`
- **ลิงก์ไปหน้าเข้าสู่ระบบ**: เพิ่มลิงก์ "ไปหน้าเข้าสู่ระบบ" แบบ Inline เมื่อข้อความแจ้งเตือนเกี่ยวข้องกับการล็อกอิน